### PR TITLE
Add timeout handling to Textract analysis

### DIFF
--- a/test/test_textract_timeout.py
+++ b/test/test_textract_timeout.py
@@ -1,0 +1,23 @@
+import importlib
+from unittest.mock import Mock
+import pytest
+
+textract_module = importlib.import_module("lambda.extraction_lambda")
+
+
+def test_textract_analyze_timeout(monkeypatch):
+    # Mock Textract client to always return IN_PROGRESS
+    dummy = Mock()
+    dummy.start_document_analysis.return_value = {"JobId": "123"}
+    dummy.get_document_analysis.return_value = {"JobStatus": "IN_PROGRESS"}
+
+    monkeypatch.setattr(textract_module, "client", lambda service: dummy)
+    # Avoid sleeping during test
+    monkeypatch.setattr(textract_module.time, "sleep", lambda x: None)
+
+    with pytest.raises(TimeoutError) as excinfo:
+        textract_module._textract_analyze("bucket", "file.pdf", max_attempts=2)
+
+    assert "timed out" in str(excinfo.value).lower()
+    # Ensure polling happened expected number of times
+    assert dummy.get_document_analysis.call_count == 2


### PR DESCRIPTION
## Summary
- enforce polling limits in `_textract_analyze` with attempts and elapsed-time tracking
- raise TimeoutError when Textract job exceeds limits
- add unit test verifying timeout behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c10c7ad25883269cb663f179c58b45