### PR TITLE
Handle missing pandas in extract_data

### DIFF
--- a/lambda/extraction_lambda.py
+++ b/lambda/extraction_lambda.py
@@ -199,6 +199,10 @@ def extract_data(bucket=None, key=None, local_path=None):
             text = _local_pdf_fallback(local_path)
             return _parse_from_text(text)
         elif local_path.lower().endswith(".xlsx"):
+            if pd is None:
+                raise ImportError(
+                    "pandas is required to read Excel files. Install it with `pip install pandas`."
+                )
             df = pd.read_excel(local_path)
             # Expect columns: Name, Code, Rate, Hours, Total
             labor = df.to_dict("records")

--- a/test/test_extraction.py
+++ b/test/test_extraction.py
@@ -1,9 +1,19 @@
 import importlib
-extract_data = importlib.import_module("lambda.extraction_lambda").extract_data
 import os
+import pytest
+
+extraction_lambda = importlib.import_module("lambda.extraction_lambda")
+extract_data = extraction_lambda.extract_data
 
 def test_extract_local_pdf():
     pdf_path = os.path.join(os.path.dirname(__file__), "..", "test_invoice.pdf")
     data = extract_data(local_path=pdf_path)
     assert data["invoice_number"] == "3034894"
     assert "labor" in data and data["summary"].get("labor") == 77150.25
+
+
+def test_extract_xlsx_without_pandas(monkeypatch):
+    monkeypatch.setattr(extraction_lambda, "pd", None)
+    with pytest.raises(ImportError) as excinfo:
+        extract_data(local_path="dummy.xlsx")
+    assert "pip install pandas" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- verify `pd` is available before reading Excel in `extract_data`
- raise helpful ImportError when pandas isn't installed
- add unit test simulating missing pandas

## Testing
- `pytest test/test_extraction.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c10e39bb948326b7aac31547c29a80